### PR TITLE
Fix Windows build errors by upgrading to Winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,11 @@ parking_lot = "0"
 regex = "0.2"
 unicode-width = "0.1"
 
+[patch.crates-io]
+clicolors-control = { git = "https://github.com/repi/clicolors-control", branch="winapi-0.3" }
+
 [target.'cfg(unix)'.dependencies]
 termios = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0"
-kernel32-sys = "0"
+winapi = { version = "0.3", features = ["winbase","winuser","consoleapi","processenv","wincon"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@
 #[cfg(unix)] extern crate libc;
 #[cfg(unix)] extern crate termios;
 #[cfg(windows)] extern crate winapi;
-#[cfg(windows)] extern crate kernel32;
 #[macro_use] extern crate lazy_static;
 extern crate regex;
 extern crate parking_lot;

--- a/src/term.rs
+++ b/src/term.rs
@@ -256,8 +256,9 @@ impl AsRawFd for Term {
 impl AsRawHandle for Term {
 
     fn as_raw_handle(&self) -> RawHandle {
-        use winapi::{STD_OUTPUT_HANDLE, STD_ERROR_HANDLE};
-        use kernel32::GetStdHandle;
+        use winapi::um::winbase::{STD_OUTPUT_HANDLE, STD_ERROR_HANDLE};
+        use winapi::um::processenv::{GetStdHandle};        
+
         unsafe {
             GetStdHandle(match self.target {
                 TermTarget::Stdout => STD_OUTPUT_HANDLE,


### PR DESCRIPTION
Similar to the fix in https://github.com/mitsuhiko/clicolors-control/pull/4 but for the console crate to get it to build on and run on Windows again, which it now does.

Once clicolors-control PR have been integrated then the patch dependency in this one is not needed.