### PR TITLE
Remove call to format that isn't needed.

### DIFF
--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -54,7 +54,7 @@ pub fn move_cursor_up(out: &Term, n: usize) -> io::Result<()> {
 }
 
 pub fn clear_line(out: &Term) -> io::Result<()> {
-    out.write_str(&format!("\r\x1b[2K"))
+    out.write_str("\r\x1b[2K")
 }
 
 pub fn key_from_escape_codes(buf: &[u8]) -> Key {


### PR DESCRIPTION
This call to `format!` wasn't necessary since there are no arguments.