### PR TITLE
Switch from getwch to ReadConsoleInputW

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ termios = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase","winuser","consoleapi","processenv","wincon"] }
+encode_unicode = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ extern crate libc;
 extern crate termios;
 #[cfg(windows)]
 extern crate winapi;
+#[cfg(windows)]
+extern crate encode_unicode;
 #[macro_use]
 extern crate lazy_static;
 extern crate atty;


### PR DESCRIPTION
Implemented full unicode input support. Also added error messages
when invalid UTF-16 input is read. Tested thoroughly with emoji
input.

Closes #9 