### PR TITLE
Fix multiply with overflow at clear_screen

### DIFF
--- a/src/windows_term.rs
+++ b/src/windows_term.rs
@@ -117,7 +117,7 @@ pub fn clear_screen(out: &Term) -> io::Result<()> {
     }
     if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
         unsafe {
-            let cells = csbi.dwSize.X * csbi.dwSize.Y;
+            let cells = csbi.dwSize.X as DWORD * csbi.dwSize.Y as DWORD;
             let pos = COORD { X: 0, Y: 0 };
             let mut written = 0;
             FillConsoleOutputCharacterA(hand, b' ' as CHAR, cells as DWORD, pos, &mut written);


### PR DESCRIPTION
If console window is large at Windows, `clear_screen()` becomes panic.
For example, my console is `csbi.dwSize.X` = 242 and `csbi.dwSize.Y` = 300.
So `cells` becomes 72600 and it overflows because the type of `cells` is `SHORT`(`i16`).

