### PR TITLE
Various fixes and additions

### DIFF
--- a/src/common_term.rs
+++ b/src/common_term.rs
@@ -18,6 +18,22 @@ pub fn move_cursor_up(out: &Term, n: usize) -> io::Result<()> {
     }
 }
 
+pub fn move_cursor_right(out: &Term, n: usize) -> io::Result<()> {
+    if n > 0 {
+        out.write_str(&format!("\x1b[{}C", n))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn move_cursor_left(out: &Term, n: usize) -> io::Result<()> {
+    if n > 0 {
+        out.write_str(&format!("\x1b[{}D", n))
+    } else {
+        Ok(())
+    }
+}
+
 pub fn clear_line(out: &Term) -> io::Result<()> {
     out.write_str("\r\x1b[2K")
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -210,7 +210,7 @@ impl Term {
         }
         let mut rv = String::new();
         io::stdin().read_line(&mut rv)?;
-        let len = rv.trim_right_matches(&['\r', '\n'][..]).len();
+        let len = rv.trim_end_matches(&['\r', '\n'][..]).len();
         rv.truncate(len);
         Ok(rv)
     }

--- a/src/term.rs
+++ b/src/term.rs
@@ -292,6 +292,16 @@ impl Term {
         move_cursor_down(self, n)
     }
 
+    /// Moves the cursor right `n` lines
+    pub fn move_cursor_right(&self, n: usize) -> io::Result<()> {
+        move_cursor_right(self, n)
+    }
+
+    /// Move the cursor left `n` lines
+    pub fn move_cursor_left(&self, n: usize) -> io::Result<()> {
+        move_cursor_left(self, n)
+    }
+
     /// Clears the current line.
     ///
     /// The positions the cursor at the beginning of the line again.

--- a/src/windows_term.rs
+++ b/src/windows_term.rs
@@ -65,7 +65,7 @@ pub fn move_cursor_up(out: &Term, n: usize) -> io::Result<()> {
             SetConsoleCursorPosition(
                 hand,
                 COORD {
-                    X: 0,
+                    X: csbi.dwCursorPosition.X,
                     Y: csbi.dwCursorPosition.Y - n as i16,
                 },
             );
@@ -83,8 +83,44 @@ pub fn move_cursor_down(out: &Term, n: usize) -> io::Result<()> {
             SetConsoleCursorPosition(
                 hand,
                 COORD {
-                    X: 0,
+                    X: csbi.dwCursorPosition.X,
                     Y: csbi.dwCursorPosition.Y + n as i16,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+pub fn move_cursor_right(out: &Term, n: usize) -> io::Result<()> {
+    if msys_tty_on(out) {
+        return common_term::move_cursor_right(out, n);
+    }
+    if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+        unsafe {
+            SetConsoleCursorPosition(
+                hand,
+                COORD {
+                    X: csbi.dwCursorPosition.X + n as i16,
+                    Y: csbi.dwCursorPosition.Y,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+pub fn move_cursor_left(out: &Term, n: usize) -> io::Result<()> {
+    if msys_tty_on(out) {
+        return common_term::move_cursor_left(out, n);
+    }
+    if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+        unsafe {
+            SetConsoleCursorPosition(
+                hand,
+                COORD {
+                    X: csbi.dwCursorPosition.X - n as i16,
+                    Y: csbi.dwCursorPosition.Y,
                 },
             );
         }

--- a/src/windows_term.rs
+++ b/src/windows_term.rs
@@ -10,7 +10,7 @@ use winapi;
 use winapi::ctypes::c_void;
 use winapi::shared::minwindef::DWORD;
 use winapi::shared::minwindef::MAX_PATH;
-use winapi::um::consoleapi::{GetNumberOfConsoleInputEvents, ReadConsoleInputW};
+use winapi::um::consoleapi::{GetNumberOfConsoleInputEvents, ReadConsoleInputW, ReadConsoleInputA};
 use winapi::um::fileapi::FILE_NAME_INFO;
 use winapi::um::handleapi::INVALID_HANDLE_VALUE;
 use winapi::um::minwinbase::FileNameInfo;
@@ -320,8 +320,9 @@ fn read_key_event() -> io::Result<KEY_EVENT_RECORD> {
 
         key_event = unsafe { mem::transmute(buffer.Event) };
 
-        if key_event.bKeyDown == 0 {
-            // This is a key being released; ignore it.
+        // 1st case: This is a key being released; ignore it.
+        // 2nd case: Modifier keys do not have unicodes/ascii codes.
+        if key_event.bKeyDown == 0 || unsafe { *key_event.uChar.UnicodeChar() } == 0 {
             continue;
         }
 

--- a/src/windows_term.rs
+++ b/src/windows_term.rs
@@ -328,8 +328,8 @@ fn read_key_event() -> io::Result<KEY_EVENT_RECORD> {
         // This is a shift; ignore it.
         if unsafe { *key_event.uChar.UnicodeChar() } == 0 {
             match key_event.wVirtualKeyCode as INT {
-                winapi::um::winuser::VK_LSHIFT | 
-                winapi::um::winuser::VK_RSHIFT => {
+                winapi::um::winuser::VK_SHIFT |
+                winapi::um::winuser::VK_CONTROL => {
                     continue;
                 }
                 _ => {}


### PR DESCRIPTION
This PR provides fixes for Windows and methods for horizontal cursor movement.
Read key event now properly works with modifier keys for Windows.
This also fixes vertical cursor movement for windows, in order to make it more consistent with the vertical cursor movement behavior implemented by `common_term`.


Tested on a Windows machine and Mac laptop.