### PR TITLE
Added Key::Backspace support

### DIFF
--- a/src/kb.rs
+++ b/src/kb.rs
@@ -11,6 +11,7 @@ pub enum Key {
     ArrowDown,
     Enter,
     Escape,
+    Backspace,
     Char(char),
     #[doc(hidden)]
     __More,

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -130,6 +130,7 @@ pub fn key_from_escape_codes(buf: &[u8]) -> Key {
         b"\x1b[B" => Key::ArrowDown,
         b"\n" | b"\r" => Key::Enter,
         b"\x1b" => Key::Escape,
+        b"\x7f" => Key::Backspace,
         buf => {
             if let Ok(s) = str::from_utf8(buf) {
                 if let Some(c) = s.chars().next() {


### PR DESCRIPTION
#### Checklist
* Backspace key added to `kb.rs`
* Match for backspace `UTF-8` character added to `key_from_escape_codes` in `unix_term`.

PR passes the checks and also works for my project locally.
I also noticed that the feature was already implemented for the Windows terminal. If I missed something where this should be added, please let know.

Cheers!