### PR TITLE
fix hide_cursor escape code

### DIFF
--- a/src/common_term.rs
+++ b/src/common_term.rs
@@ -37,5 +37,5 @@ pub fn show_cursor(out: &Term) -> io::Result<()> {
 
 pub fn hide_cursor(out: &Term) -> io::Result<()> {
     let esc = "\u{001B}";
-    out.write_str(&format!("{}[?251", esc))
+    out.write_str(&format!("{}[?25l", esc))
 }


### PR DESCRIPTION
Oops sorry I put a "1" instead of "l" this makes `hide_cursor` work.