### PR TITLE
Add repository url to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 license = "MIT"
 edition = "2018"
 homepage = "https://github.com/mitsuhiko/console"
+repository = "https://github.com/mitsuhiko/console"
 documentation = "https://docs.rs/console"
 readme = "README.md"
 


### PR DESCRIPTION
This makes this repository easier to find when clicking through docs.rs/console.