### PR TITLE
Make regex optional by moving ansi stripping behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,14 @@ documentation = "https://docs.rs/console"
 readme = "README.md"
 
 [features]
-default = ["unicode-width"]
+default = ["unicode-width", "ansi-parsing"]
+ansi-parsing = ["regex"]
 
 [dependencies]
 clicolors-control = "1.0.1"
 lazy_static = "1"
 libc = "0.2"
-regex = { version = "1.3.1", default-features = false, features = ["std"] }
+regex = { version = "1.3.1", optional = true, default-features = false, features = ["std"] }
 unicode-width = { version = "0.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,0 +1,103 @@
+use std::borrow::Cow;
+
+use regex::{Matches, Regex};
+
+lazy_static::lazy_static! {
+    static ref STRIP_ANSI_RE: Regex =
+        Regex::new(r"[\x1b\x9b][\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]")
+            .unwrap();
+}
+
+/// Helper function to strip ansi codes.
+pub fn strip_ansi_codes(s: &str) -> Cow<str> {
+    STRIP_ANSI_RE.replace_all(s, "")
+}
+
+/// An iterator over ansi codes in a string.
+///
+/// This type can be used to scan over ansi codes in a string.
+/// It yields tuples in the form `(s, is_ansi)` where `s` is a slice of
+/// the original string and `is_ansi` indicates if the slice contains
+/// ansi codes or string values.
+pub struct AnsiCodeIterator<'a> {
+    s: &'a str,
+    pending_item: Option<(&'a str, bool)>,
+    last_idx: usize,
+    cur_idx: usize,
+    iter: Matches<'static, 'a>,
+}
+
+impl<'a> AnsiCodeIterator<'a> {
+    /// Creates a new ansi code iterator.
+    pub fn new(s: &'a str) -> AnsiCodeIterator<'a> {
+        AnsiCodeIterator {
+            s,
+            pending_item: None,
+            last_idx: 0,
+            cur_idx: 0,
+            iter: STRIP_ANSI_RE.find_iter(s),
+        }
+    }
+
+    /// Returns the string slice up to the current match.
+    pub fn current_slice(&self) -> &str {
+        &self.s[..self.cur_idx]
+    }
+
+    /// Returns the string slice from the current match to the end.
+    pub fn rest_slice(&self) -> &str {
+        &self.s[self.cur_idx..]
+    }
+}
+
+impl<'a> Iterator for AnsiCodeIterator<'a> {
+    type Item = (&'a str, bool);
+
+    fn next(&mut self) -> Option<(&'a str, bool)> {
+        if let Some(pending_item) = self.pending_item.take() {
+            self.cur_idx += pending_item.0.len();
+            Some(pending_item)
+        } else if let Some(m) = self.iter.next() {
+            let s = &self.s[self.last_idx..m.start()];
+            self.last_idx = m.end();
+            if s.is_empty() {
+                self.cur_idx = m.end();
+                Some((m.as_str(), true))
+            } else {
+                self.cur_idx = m.start();
+                self.pending_item = Some((m.as_str(), true));
+                Some((s, false))
+            }
+        } else if self.last_idx < self.s.len() {
+            let rv = &self.s[self.last_idx..];
+            self.cur_idx = self.s.len();
+            self.last_idx = self.s.len();
+            Some((rv, false))
+        } else {
+            None
+        }
+    }
+}
+
+#[test]
+fn test_ansi_iter_re() {
+    use crate::style;
+    let s = format!("Hello {}!", style("World").red().force_styling(true));
+    let mut iter = AnsiCodeIterator::new(&s);
+    assert_eq!(iter.next(), Some(("Hello ", false)));
+    assert_eq!(iter.current_slice(), "Hello ");
+    assert_eq!(iter.rest_slice(), "\x1b[31mWorld\x1b[0m!");
+    assert_eq!(iter.next(), Some(("\x1b[31m", true)));
+    assert_eq!(iter.current_slice(), "Hello \x1b[31m");
+    assert_eq!(iter.rest_slice(), "World\x1b[0m!");
+    assert_eq!(iter.next(), Some(("World", false)));
+    assert_eq!(iter.current_slice(), "Hello \x1b[31mWorld");
+    assert_eq!(iter.rest_slice(), "\x1b[0m!");
+    assert_eq!(iter.next(), Some(("\x1b[0m", true)));
+    assert_eq!(iter.current_slice(), "Hello \x1b[31mWorld\x1b[0m");
+    assert_eq!(iter.rest_slice(), "!");
+    assert_eq!(iter.next(), Some(("!", false)));
+    assert_eq!(iter.current_slice(), "Hello \x1b[31mWorld\x1b[0m!");
+    assert_eq!(iter.rest_slice(), "");
+    assert_eq!(iter.next(), None);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,25 @@
 //! By default this crate depends on the `unicode-width` crate to calculate
 //! the width of terminal characters.  If you do not need this you can disable
 //! the `unicode-width` feature which will cut down on dependencies.
+//!
+//! # Features
+//!
+//! By default all features are enabled.  The following features exist:
+//!
+//! * `unicode-width`: adds support for unicode width calculations
+//! * `ansi-parsing`: adds support for parsing ansi codes (this adds support
+//!   for stripping and taking ansi escape codes into account for length
+//!   calculations).
 
 pub use crate::kb::Key;
 pub use crate::term::{user_attended, Term, TermFamily, TermFeatures, TermTarget};
 pub use crate::utils::{
-    colors_enabled, measure_text_width, pad_str, set_colors_enabled, strip_ansi_codes, style,
-    truncate_str, Alignment, AnsiCodeIterator, Attribute, Color, Emoji, Style, StyledObject,
+    colors_enabled, measure_text_width, pad_str, set_colors_enabled, style, truncate_str,
+    Alignment, Attribute, Color, Emoji, Style, StyledObject,
 };
+
+#[cfg(feature = "ansi-parsing")]
+pub use crate::ansi::{strip_ansi_codes, AnsiCodeIterator};
 
 mod common_term;
 mod kb;
@@ -84,3 +96,6 @@ mod utils;
 mod wasm_term;
 #[cfg(windows)]
 mod windows_term;
+
+#[cfg(feature = "ansi-parsing")]
+mod ansi;


### PR DESCRIPTION
Make regex dependency optional. This should help cutting down dependencies of insta (https://github.com/mitsuhiko/insta/issues/102).