### PR TITLE
Enable emoji for new Windows Terminal

### DIFF
--- a/src/windows_term.rs
+++ b/src/windows_term.rs
@@ -1,4 +1,5 @@
 use std::char;
+use std::env;
 use std::ffi::OsStr;
 use std::fmt::Display;
 use std::io;
@@ -334,7 +335,8 @@ fn read_key_event() -> io::Result<KEY_EVENT_RECORD> {
 }
 
 pub fn wants_emoji() -> bool {
-    false
+    // If WT_SESSION is set, we can assume we're running in the new Windows Terminal.
+    env::var("WT_SESSION").is_ok()
 }
 
 /// Returns true if there is an MSYS tty on the given handle.


### PR DESCRIPTION
The new Windows Terminal (https://github.com/microsoft/terminal) has
full emoji support.

Detect the WT_SESSION environment variable, which is set when running
under this terminal, and enable emoji if it's set.

In the future, a more standardized variable may be set.

References:
  - https://github.com/microsoft/terminal/blob/master/doc/user-docs/index.md#tips-and-tricks
  - https://github.com/microsoft/terminal/issues/1040

## Examples
### In cmd.exe:
![image](https://user-images.githubusercontent.com/5890747/77320388-659a5300-6d08-11ea-9dde-4c08b4e4d820.png)

### In new Windows Terminal:
![image](https://user-images.githubusercontent.com/5890747/77320400-6cc16100-6d08-11ea-8579-f26496b4ba74.png)
