### PR TITLE
Add "Key::Unknown" handling everywhere it was missing

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -188,6 +188,12 @@ impl Term {
                 Key::Enter => {
                     return Ok('\n');
                 }
+                Key::Unknown => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "Not a terminal",
+                    ))
+                }
                 _ => {}
             }
         }
@@ -248,6 +254,12 @@ impl Term {
                     self.flush()?;
                 }
                 Key::Enter => break,
+                Key::Unknown => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "Not a terminal",
+                    ))
+                }
                 _ => (),
             }
         }


### PR DESCRIPTION
Working on a project. Turns out i need to test that a dialogue outputs
a certain way. Turns out there's no way to do that because the case of
"not a terminal" is not handled! It's a quick fix, might as well. I've
done the same for dialoguer.