### PR TITLE
Depend on `winapi-util` 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ termios = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase", "winuser", "consoleapi", "processenv", "wincon"] }
-winapi-util = { version = "0.1", optional = true }
+winapi-util = { version = "0.1.3", optional = true }
 encode_unicode = "0.3"


### PR DESCRIPTION
The package depends on things added in that version - https://github.com/BurntSushi/winapi-util/commit/d33486e0c0c7ef73450ac02a563d914906768827

Fixes issues such as https://github.com/rust-lang/cargo-bisect-rustc/issues/89