### PR TITLE
Return immediately if Esc is pressed

### DIFF
--- a/src/kb.rs
+++ b/src/kb.rs
@@ -5,6 +5,8 @@
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Key {
     Unknown,
+    // Escape followed by an unrecognized sequence
+    UnknownEscSeq,
     ArrowLeft,
     ArrowRight,
     ArrowUp,
@@ -15,7 +17,11 @@ pub enum Key {
     Home,
     End,
     Tab,
+    BackTab,
     Del,
+    Insert,
+    PageUp,
+    PageDown,
     Char(char),
     #[doc(hidden)]
     __More,

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -2,11 +2,11 @@
 ///
 /// This is an incomplete mapping of keys that are supported for reading
 /// from the keyboard.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Key {
     Unknown,
-    // Escape followed by an unrecognized sequence
-    UnknownEscSeq,
+    /// Unrecognized sequence containing Esc and a list of chars
+    UnknownEscSeq(Vec<char>),
     ArrowLeft,
     ArrowRight,
     ArrowUp,

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -2,6 +2,7 @@
 ///
 /// This is an incomplete mapping of keys that are supported for reading
 /// from the keyboard.
+#[non_exhaustive]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Key {
     Unknown,
@@ -23,6 +24,4 @@ pub enum Key {
     PageUp,
     PageDown,
     Char(char),
-    #[doc(hidden)]
-    __More,
 }

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -183,8 +183,7 @@ pub fn read_single_key() -> io::Result<Key> {
         }
         Some(c) => {
             let byte = c as u8;
-            let mut buf = [0u8; 4];
-            buf[0] = byte;
+            let mut buf: [u8; 4] = [byte, 0, 0, 0];
 
             if byte & 224u8 == 192u8 {
                 // a two byte unicode character

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -133,8 +133,7 @@ pub fn read_single_key() -> io::Result<Key> {
     unsafe { libc::cfmakeraw(&mut termios) };
     c_result(|| unsafe { libc::tcsetattr(fd, libc::TCSADRAIN, &termios) })?;
 
-    let byte = read_single_char(fd)?;
-    let rv = match byte {
+    let rv = match read_single_char(fd)? {
         Some('\x1b') => {
             // Escape was read, keep reading in case we find a familiar key
             if let Some(c1) = read_single_char(fd)? {

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -162,20 +162,20 @@ pub fn read_single_key() -> io::Result<Key> {
                                             '3' => Ok(Key::Del),
                                             '5' => Ok(Key::PageUp),
                                             '6' => Ok(Key::PageDown),
-                                            _ => Ok(Key::UnknownEscSeq(vec![c2])),
+                                            _ => Ok(Key::UnknownEscSeq(vec![c1, c2, c3])),
                                         }
                                     } else {
-                                        Ok(Key::UnknownEscSeq(vec![c2, c3]))
+                                        Ok(Key::UnknownEscSeq(vec![c1, c2, c3]))
                                     }
                                 } else {
                                     // \x1b[ and 1 more char
-                                    Ok(Key::UnknownEscSeq(vec![c2]))
+                                    Ok(Key::UnknownEscSeq(vec![c1, c2]))
                                 }
                             }
                         }
                     } else {
                         // \x1b[ and no more input
-                        Ok(Key::UnknownEscSeq(vec![]))
+                        Ok(Key::UnknownEscSeq(vec![c1]))
                     }
                 } else {
                     // char after escape is not [

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -164,17 +164,17 @@ pub fn read_single_key() -> io::Result<Key> {
                                     }
                                 } else {
                                     // \x1b[ and 1 more char
-                                    Ok(Key::Escape)
+                                    Ok(Key::UnknownEscSeq)
                                 }
                             }
                         }
                     } else {
                         // \x1b[ and no more input
-                        Ok(Key::Escape)
+                        Ok(Key::UnknownEscSeq)
                     }
                 } else {
                     // char after escape is not [
-                    Ok(Key::Escape)
+                    Ok(Key::UnknownEscSeq)
                 }
             } else {
                 //nothing after escape

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -96,12 +96,7 @@ fn read_single_char(fd: i32) -> io::Result<Option<char>> {
     let is_ready = pollfd.revents & libc::POLLIN != 0;
 
     if is_ready {
-        //there is something to be read
-
-        // let mut buf: [u8; 1] = [0];
-        // let read = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, 1) };
-
-        //read only 1 byte
+        // if there is something to be read, take 1 byte from it
         let mut byte: u8 = 0;
         let read = unsafe { libc::read(fd, &mut byte as *mut u8 as _, 1) };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,8 +16,9 @@ fn strip_ansi_codes(s: &str) -> &str {
 }
 
 fn default_colors_enabled(out: &Term) -> bool {
-    (out.features().colors_supported() && &env::var("CLICOLOR").unwrap_or("1".into()) != "0")
-        || &env::var("CLICOLOR_FORCE").unwrap_or("0".into()) != "0"
+    (out.features().colors_supported()
+        && &env::var("CLICOLOR").unwrap_or_else(|_| "1".into()) != "0")
+        || &env::var("CLICOLOR_FORCE").unwrap_or_else(|_| "0".into()) != "0"
 }
 
 lazy_static! {


### PR DESCRIPTION
Fixes #66

The issue that this PR tackles is that if a user presses Esc, no key will be detected until a subsequent key is pressed.
To fix the blocking on escape issue, I use `libc::poll` to check whether there is something to be read from the fd. If not, return the key immediately. If yes, continue reading bytes one by one until we find something familiar. `read_single_key` will block if there is nothing to be read at all.
To achieve this I created a `read_single_char` function that will immediately read, or return None if the fd is not ready.

An issue in the implementation was that when Esc is pressed + some unrecognized character, only Esc was returned and the next chars were lost. I added an additional Key enum, `UnknownEscSeq`, that can holds the consumed characters.

##### On key recognition:

The amount of supported keys could be greatly extended. I think, however, that it should be in a different PR. The list is huge - [spec](https://www.xfree86.org/current/ctlseqs.html) + [how rustyline does it](https://github.com/kkawakam/rustyline/blob/master/src/tty/unix.rs). In order to attempt something like this, it would require some refactoring. For instance, make the Key enum a struct to hold a Modifiers enum. Also, the Windows implementation will have to be kept in sync.

This PR adds the logic to detect a few sequences in `read_single_key` but this should be a temporary solution. Since the logic is not too complex for now, I decided to keep it there. It should be extracted once CSI and SS3 sequences are properly handled.

On the other hand, rustyline might be introduced and make all of this unnecessary.