### PR TITLE
Mention terminal size is rows and columns

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -331,7 +331,7 @@ impl Term {
         TermFeatures(self)
     }
 
-    /// Returns the terminal size or gets sensible defaults.
+    /// Returns the terminal size in rows and columns or gets sensible defaults.
     #[inline]
     pub fn size(&self) -> (u16, u16) {
         self.size_checked().unwrap_or((24, DEFAULT_WIDTH))


### PR DESCRIPTION
It would be clearer to mention the same thing for size_unchecked.