### PR TITLE
Make windows console colors optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * Added emoji support for newer Windows terminals.
+* Made the windows terminal emulation a non default feature (`windows-console-colors`)
 
 ## 0.13.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/console"
 readme = "README.md"
 
 [features]
-default = ["unicode-width", "ansi-parsing", "windows-console-colors"]
+default = ["unicode-width", "ansi-parsing"]
 windows-console-colors = ["ansi-parsing", "winapi-util"]
 ansi-parsing = ["regex"]
 

--- a/src/windows_term.rs
+++ b/src/windows_term.rs
@@ -52,7 +52,7 @@ pub const DEFAULT_WIDTH: u16 = 79;
 pub fn as_handle(term: &Term) -> HANDLE {
     // convert between winapi::um::winnt::HANDLE and std::os::windows::raw::HANDLE
     // which are both c_void. would be nice to find a better way to do this
-    unsafe { ::std::mem::transmute(term.as_raw_handle()) }
+    term.as_raw_handle() as HANDLE
 }
 
 pub fn is_a_terminal(out: &Term) -> bool {


### PR DESCRIPTION
The changes to make emulate the ansi codes for older windows versions are buggy. It's also unclear if this feature has any realistic benefit since people are more likely to run console apps on windows 10.

This removes the feature from the default feature list to give people a better user experience.

See #69.