### PR TITLE
Fix documentation typo

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -166,7 +166,7 @@ impl Term {
         }
     }
 
-    /// Returns the targert
+    /// Returns the target
     #[inline]
     pub fn target(&self) -> TermTarget {
         self.inner.target


### PR DESCRIPTION
`targert` :arrow_right: `target`