### PR TITLE
feat: unix term escape sequences: add Home and End support for tmux and rxvt

### DIFF
--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -165,10 +165,14 @@ pub fn read_single_key() -> io::Result<Key> {
                                 if let Some(c3) = c3 {
                                     if c3 == '~' {
                                         match c2 {
+                                            '1' => Ok(Key::Home), // tmux
                                             '2' => Ok(Key::Insert),
                                             '3' => Ok(Key::Del),
+                                            '4' => Ok(Key::End), // tmux
                                             '5' => Ok(Key::PageUp),
                                             '6' => Ok(Key::PageDown),
+                                            '7' => Ok(Key::Home), // xrvt
+                                            '8' => Ok(Key::End),  // xrvt
                                             _ => Ok(Key::UnknownEscSeq(vec![c1, c2, c3])),
                                         }
                                     } else {


### PR DESCRIPTION

for most vte based terminals, current implementation is good, for example gnome-terminal:

```bash
❯ showkey -a

Press any keys - Ctrl-D will terminate this program

^[[H 	 27 0033 0x1b
 	 91 0133 0x5b
 	 72 0110 0x48
^[[F 	 27 0033 0x1b
 	 91 0133 0x5b
 	 70 0106 0x46
```

but tmux is a bit different:

```bash
❯ showkey -a

Press any keys - Ctrl-D will terminate this program

^[[1~    27 0033 0x1b
         91 0133 0x5b
         49 0061 0x31
        126 0176 0x7e
^[[4~    27 0033 0x1b
         91 0133 0x5b
         52 0064 0x34
        126 0176 0x7e
```

see https://en.wikipedia.org/wiki/ANSI_escape_code#Terminal_input_sequences

other implements ref:   https://github.com/prompt-toolkit/python-prompt-toolkit/blob/0ae9aa688e0b3f81a29a33015ca1f8a9adb05c6c/prompt_toolkit/input/ansi_escape_sequences.py#L68


