### PR TITLE
feat: unix term add Control-A (home), Control-E (end) and Control-H support

### DIFF
--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -214,6 +214,9 @@ pub fn read_single_key() -> io::Result<Key> {
                     '\n' | '\r' => Key::Enter,
                     '\x7f' => Key::Backspace,
                     '\t' => Key::Tab,
+                    '\x01' => Key::Home,      // Control-A (home)
+                    '\x05' => Key::End,       // Control-E (end)
+                    '\x08' => Key::Backspace, // Control-H (8) (Identical to '\b')
                     _ => Key::Char(c),
                 })
             }


### PR DESCRIPTION

feat: unix term add Control-A (home), Control-E (end) and Control-H (8) support

ref to https://github.com/prompt-toolkit/python-prompt-toolkit/blob/0ae9aa688e0b3f81a29a33015ca1f8a9adb05c6c/prompt_toolkit/input/ansi_escape_sequences.py#L26