### PR TITLE
Add NO_COLOR support

### DIFF
--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -23,6 +23,10 @@ pub fn is_a_color_terminal(out: &Term) -> bool {
         return false;
     }
 
+    if let Ok(_) = env::var("NO_COLOR") {
+        return false;
+    }
+    
     match env::var("TERM") {
         Ok(term) => term != "dumb",
         Err(_) => false,

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -23,10 +23,10 @@ pub fn is_a_color_terminal(out: &Term) -> bool {
         return false;
     }
 
-    if let Ok(_) = env::var("NO_COLOR") {
+    if env::var("NO_COLOR").is_ok() {
         return false;
     }
-    
+
     match env::var("TERM") {
         Ok(term) => term != "dumb",
         Err(_) => false,


### PR DESCRIPTION
The NO_COLOR variable appears to be a bit of a standard variable for handling this. See https://no-color.org/. `termcolor` also supports this https://docs.rs/termcolor/1.1.2/i686-unknown-linux-gnu/termcolor/enum.ColorChoice.html.