### PR TITLE
Revert "Add NO_COLOR support"

### DIFF
--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -23,10 +23,6 @@ pub fn is_a_color_terminal(out: &Term) -> bool {
         return false;
     }
 
-    if env::var("NO_COLOR").is_ok() {
-        return false;
-    }
-
     match env::var("TERM") {
         Ok(term) => term != "dumb",
         Err(_) => false,


### PR DESCRIPTION
This is not how color handling should be done. It's must be controlled by `clicolors-control`.

Reverts mitsuhiko/console#89