### PR TITLE
Add VT100 character set sequences to STRIP_ANSI_RE

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -4,7 +4,7 @@ use regex::{Matches, Regex};
 
 lazy_static::lazy_static! {
     static ref STRIP_ANSI_RE: Regex =
-        Regex::new(r"[\x1b\x9b][\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]")
+        Regex::new(r"[\x1b\x9b]([()][012AB]|[\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><])")
             .unwrap();
 }
 
@@ -77,6 +77,16 @@ impl<'a> Iterator for AnsiCodeIterator<'a> {
             None
         }
     }
+}
+
+#[test]
+fn test_ansi_iter_re_vt100() {
+    let s = "\x1b(0lpq\x1b)Benglish";
+    let mut iter = AnsiCodeIterator::new(s);
+    assert_eq!(iter.next(), Some(("\x1b(0", true)));
+    assert_eq!(iter.next(), Some(("lpq", false)));
+    assert_eq!(iter.next(), Some(("\x1b)B", true)));
+    assert_eq!(iter.next(), Some(("english", false)));
 }
 
 #[test]


### PR DESCRIPTION
This pull request adds support for stripping/iterating a couple VT100 escape sequences alongside the ANSI ones.

While VT100 isn't technically ANSI, most modern terminals still implement a subset of them. The changes specifically add support for the sequences responsible for switching between the box-drawing and regular character sets.
