### PR TITLE
add shift to recognized inputs

### DIFF
--- a/src/kb.rs
+++ b/src/kb.rs
@@ -20,6 +20,7 @@ pub enum Key {
     Tab,
     BackTab,
     Del,
+    Shift,
     Insert,
     PageUp,
     PageDown,

--- a/src/windows_term.rs
+++ b/src/windows_term.rs
@@ -329,6 +329,7 @@ pub fn key_from_key_code(code: INT) -> Key {
         winapi::um::winuser::VK_HOME => Key::Home,
         winapi::um::winuser::VK_END => Key::End,
         winapi::um::winuser::VK_DELETE => Key::Del,
+        winapi::um::winuser::VK_SHIFT => Key::Shift,
         _ => Key::Unknown,
     }
 }


### PR DESCRIPTION
This fixes an [issue](https://github.com/mitsuhiko/dialoguer/issues/110) on a crate that depends on this one, namely [dialoguer](https://github.com/mitsuhiko/dialoguer).

The problem is that shift is not recognized as a valid input under windows cancelling the text_input routine. This allows `shift` to be handled and with that the input of upper case letters on Windows 10.