### PR TITLE
Exported `pad-str-with` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,9 +81,9 @@ pub use crate::term::{
     user_attended, user_attended_stderr, Term, TermFamily, TermFeatures, TermTarget,
 };
 pub use crate::utils::{
-    colors_enabled, colors_enabled_stderr, measure_text_width, pad_str, set_colors_enabled,
-    set_colors_enabled_stderr, style, truncate_str, Alignment, Attribute, Color, Emoji, Style,
-    StyledObject,
+    colors_enabled, colors_enabled_stderr, measure_text_width, pad_str, pad_str_with,
+    set_colors_enabled, set_colors_enabled_stderr, style, truncate_str, Alignment,
+    Attribute, Color, Emoji, Style, StyledObject,
 };
 
 #[cfg(feature = "ansi-parsing")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,8 @@ pub use crate::term::{
 };
 pub use crate::utils::{
     colors_enabled, colors_enabled_stderr, measure_text_width, pad_str, pad_str_with,
-    set_colors_enabled, set_colors_enabled_stderr, style, truncate_str, Alignment,
-    Attribute, Color, Emoji, Style, StyledObject,
+    set_colors_enabled, set_colors_enabled_stderr, style, truncate_str, Alignment, Attribute,
+    Color, Emoji, Style, StyledObject,
 };
 
 #[cfg(feature = "ansi-parsing")]


### PR DESCRIPTION
Hi, I think `pad-str-with` is not a implementation detail and should be available to uses.