### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/windows_term.rs
+++ b/src/windows_term.rs
@@ -95,21 +95,21 @@ pub fn is_a_color_terminal(out: &Term) -> bool {
 }
 
 fn enable_ansi_on(out: &Term) -> bool {
-    unsafe {
+    
         let handle = as_handle(out);
 
         let mut dw_mode = 0;
-        if GetConsoleMode(handle, &mut dw_mode) == 0 {
+        if unsafe { GetConsoleMode(handle, &mut dw_mode) == 0 }{
             return false;
         }
 
         dw_mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-        if SetConsoleMode(handle, dw_mode) == 0 {
+        if unsafe { SetConsoleMode(handle, dw_mode) == 0 }{
             return false;
         }
 
         true
-    }
+    
 }
 
 unsafe fn console_on_any(fds: &[DWORD]) -> bool {
@@ -203,13 +203,13 @@ pub fn clear_line(out: &Term) -> io::Result<()> {
         return common_term::clear_line(out);
     }
     if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+        let width = csbi.srWindow.Right - csbi.srWindow.Left;
+        let pos = COORD {
+            X: 0,
+            Y: csbi.dwCursorPosition.Y,
+        };
+        let mut written = 0;
         unsafe {
-            let width = csbi.srWindow.Right - csbi.srWindow.Left;
-            let pos = COORD {
-                X: 0,
-                Y: csbi.dwCursorPosition.Y,
-            };
-            let mut written = 0;
             FillConsoleOutputCharacterA(hand, b' ' as CHAR, width as DWORD, pos, &mut written);
             FillConsoleOutputAttribute(hand, csbi.wAttributes, width as DWORD, pos, &mut written);
             SetConsoleCursorPosition(hand, pos);
@@ -223,13 +223,13 @@ pub fn clear_chars(out: &Term, n: usize) -> io::Result<()> {
         return common_term::clear_chars(out, n);
     }
     if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+        let width = cmp::min(csbi.dwCursorPosition.X, n as i16);
+        let pos = COORD {
+            X: csbi.dwCursorPosition.X - width,
+            Y: csbi.dwCursorPosition.Y,
+        };
+        let mut written = 0;
         unsafe {
-            let width = cmp::min(csbi.dwCursorPosition.X, n as i16);
-            let pos = COORD {
-                X: csbi.dwCursorPosition.X - width,
-                Y: csbi.dwCursorPosition.Y,
-            };
-            let mut written = 0;
             FillConsoleOutputCharacterA(hand, b' ' as CHAR, width as DWORD, pos, &mut written);
             FillConsoleOutputAttribute(hand, csbi.wAttributes, width as DWORD, pos, &mut written);
             SetConsoleCursorPosition(hand, pos);
@@ -243,10 +243,10 @@ pub fn clear_screen(out: &Term) -> io::Result<()> {
         return common_term::clear_screen(out);
     }
     if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+        let cells = csbi.dwSize.X as DWORD * csbi.dwSize.Y as DWORD; // as DWORD, or else this causes stack overflows.
+        let pos = COORD { X: 0, Y: 0 };
+        let mut written = 0;
         unsafe {
-            let cells = csbi.dwSize.X as DWORD * csbi.dwSize.Y as DWORD; // as DWORD, or else this causes stack overflows.
-            let pos = COORD { X: 0, Y: 0 };
-            let mut written = 0;
             FillConsoleOutputCharacterA(hand, b' ' as CHAR, cells, pos, &mut written); // cells as DWORD no longer needed.
             FillConsoleOutputAttribute(hand, csbi.wAttributes, cells, pos, &mut written);
             SetConsoleCursorPosition(hand, pos);
@@ -260,15 +260,15 @@ pub fn clear_to_end_of_screen(out: &Term) -> io::Result<()> {
         return common_term::clear_to_end_of_screen(out);
     }
     if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+        let bottom = csbi.srWindow.Right as DWORD * csbi.srWindow.Bottom as DWORD;
+        let cells =
+            bottom - (csbi.dwCursorPosition.X as DWORD * csbi.dwCursorPosition.Y as DWORD); // as DWORD, or else this causes stack overflows.
+        let pos = COORD {
+            X: 0,
+            Y: csbi.dwCursorPosition.Y,
+        };
+        let mut written = 0;
         unsafe {
-            let bottom = csbi.srWindow.Right as DWORD * csbi.srWindow.Bottom as DWORD;
-            let cells =
-                bottom - (csbi.dwCursorPosition.X as DWORD * csbi.dwCursorPosition.Y as DWORD); // as DWORD, or else this causes stack overflows.
-            let pos = COORD {
-                X: 0,
-                Y: csbi.dwCursorPosition.Y,
-            };
-            let mut written = 0;
             FillConsoleOutputCharacterA(hand, b' ' as CHAR, cells, pos, &mut written); // cells as DWORD no longer needed.
             FillConsoleOutputAttribute(hand, csbi.wAttributes, cells, pos, &mut written);
             SetConsoleCursorPosition(hand, pos);
@@ -282,8 +282,8 @@ pub fn show_cursor(out: &Term) -> io::Result<()> {
         return common_term::show_cursor(out);
     }
     if let Some((hand, mut cci)) = get_console_cursor_info(as_handle(out)) {
+        cci.bVisible = 1;
         unsafe {
-            cci.bVisible = 1;
             SetConsoleCursorInfo(hand, &cci);
         }
     }
@@ -295,8 +295,8 @@ pub fn hide_cursor(out: &Term) -> io::Result<()> {
         return common_term::hide_cursor(out);
     }
     if let Some((hand, mut cci)) = get_console_cursor_info(as_handle(out)) {
+        cci.bVisible = 0;
         unsafe {
-            cci.bVisible = 0;
             SetConsoleCursorInfo(hand, &cci);
         }
     }


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. However, I found that only 5 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the GetConsoleMode()/FillConsoleOutputCharacterA()/FillConsoleOutputAttribute()/SetConsoleCursorPosition()/
    SetConsoleCursorInfo() function(these are unsafe functions)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 