### PR TITLE
docs: add note about clicolors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ term.clear_line()?;
 
 ## Colors and Styles
 
-`console` automatically detects when to use colors based on the tty flag.  It also
+`console` automatically detects when to use colors based on the tty flag, following the
+[clicolors standard](https://bixense.com/clicolors/) for color enabling/disabling. It also
 provides higher level wrappers for styling text and other things that can be
 displayed with the `style` function and utility types.
 


### PR DESCRIPTION
Hi,
I wanted to enable colors in a gitlab CI job and it took me a while to figure out how to set the environment variables. Thus I slightly modified the readme to include a link to the clicolors standard

Thanks!