### PR TITLE
chore: Remove redudant helper and add `TermInner` constructors

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -45,6 +45,25 @@ struct TermInner {
     prompt_guard: Mutex<()>,
 }
 
+impl TermInner {
+    fn new(target: TermTarget) -> Self {
+        Self::with_buffer(target, None)
+    }
+
+    fn new_buffered(target: TermTarget) -> Self {
+        Self::with_buffer(target, Some(vec![]))
+    }
+
+    fn with_buffer(target: TermTarget, buffer: Option<Vec<u8>>) -> Self {
+        Self {
+            target,
+            buffer: buffer.map(Mutex::new),
+            prompt: RwLock::new(String::new()),
+            prompt_guard: Mutex::new(()),
+        }
+    }
+}
+
 /// The family of the terminal.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TermFamily {
@@ -153,43 +172,23 @@ impl Term {
     /// Return a new unbuffered terminal.
     #[inline]
     pub fn stdout() -> Term {
-        Term::with_inner(TermInner {
-            target: TermTarget::Stdout,
-            buffer: None,
-            prompt: RwLock::new(String::new()),
-            prompt_guard: Mutex::new(()),
-        })
+        Term::with_inner(TermInner::new(TermTarget::Stdout))
     }
 
     /// Return a new unbuffered terminal to stderr.
     #[inline]
     pub fn stderr() -> Term {
-        Term::with_inner(TermInner {
-            target: TermTarget::Stderr,
-            buffer: None,
-            prompt: RwLock::new(String::new()),
-            prompt_guard: Mutex::new(()),
-        })
+        Term::with_inner(TermInner::new(TermTarget::Stderr))
     }
 
     /// Return a new buffered terminal.
     pub fn buffered_stdout() -> Term {
-        Term::with_inner(TermInner {
-            target: TermTarget::Stdout,
-            buffer: Some(Mutex::new(vec![])),
-            prompt: RwLock::new(String::new()),
-            prompt_guard: Mutex::new(()),
-        })
+        Term::with_inner(TermInner::new_buffered(TermTarget::Stdout))
     }
 
     /// Return a new buffered terminal to stderr.
     pub fn buffered_stderr() -> Term {
-        Term::with_inner(TermInner {
-            target: TermTarget::Stderr,
-            buffer: Some(Mutex::new(vec![])),
-            prompt: RwLock::new(String::new()),
-            prompt_guard: Mutex::new(()),
-        })
+        Term::with_inner(TermInner::new_buffered(TermTarget::Stderr))
     }
 
     /// Return a terminal for the given Read/Write pair styled like stderr.
@@ -209,16 +208,11 @@ impl Term {
         R: Read + Debug + AsRawFd + Send + 'static,
         W: Write + Debug + AsRawFd + Send + 'static,
     {
-        Term::with_inner(TermInner {
-            target: TermTarget::ReadWritePair(ReadWritePair {
-                read: Arc::new(Mutex::new(read)),
-                write: Arc::new(Mutex::new(write)),
-                style,
-            }),
-            buffer: None,
-            prompt: RwLock::new(String::new()),
-            prompt_guard: Mutex::new(()),
-        })
+        Term::with_inner(TermInner::new(TermTarget::ReadWritePair(ReadWritePair {
+            read: Arc::new(Mutex::new(read)),
+            write: Arc::new(Mutex::new(write)),
+            style,
+        })))
     }
 
     /// Return the style for this terminal.

--- a/src/windows_term/mod.rs
+++ b/src/windows_term/mod.rs
@@ -36,11 +36,6 @@ pub(crate) use self::colors::*;
 
 pub(crate) const DEFAULT_WIDTH: u16 = 79;
 
-pub(crate) fn as_handle(term: &Term) -> HANDLE {
-    // convert between windows_sys::Win32::Foundation::HANDLE and std::os::windows::raw::HANDLE
-    term.as_raw_handle() as HANDLE
-}
-
 pub(crate) fn is_a_terminal(out: &Term) -> bool {
     let (fd, others) = match out.target() {
         TermTarget::Stdout => (STD_OUTPUT_HANDLE, [STD_INPUT_HANDLE, STD_ERROR_HANDLE]),
@@ -196,7 +191,7 @@ pub(crate) fn move_cursor_to(out: &Term, x: usize, y: usize) -> io::Result<()> {
     if out.is_msys_tty {
         return common_term::move_cursor_to(out, x, y);
     }
-    if let Some((hand, _)) = get_console_screen_buffer_info(as_handle(out)) {
+    if let Some((hand, _)) = get_console_screen_buffer_info(out.as_raw_handle()) {
         unsafe {
             SetConsoleCursorPosition(
                 hand,
@@ -215,7 +210,7 @@ pub(crate) fn move_cursor_up(out: &Term, n: usize) -> io::Result<()> {
         return common_term::move_cursor_up(out, n);
     }
 
-    if let Some((_, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+    if let Some((_, csbi)) = get_console_screen_buffer_info(out.as_raw_handle()) {
         move_cursor_to(out, 0, csbi.dwCursorPosition.Y as usize - n)?;
     }
     Ok(())
@@ -226,7 +221,7 @@ pub(crate) fn move_cursor_down(out: &Term, n: usize) -> io::Result<()> {
         return common_term::move_cursor_down(out, n);
     }
 
-    if let Some((_, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+    if let Some((_, csbi)) = get_console_screen_buffer_info(out.as_raw_handle()) {
         move_cursor_to(out, 0, csbi.dwCursorPosition.Y as usize + n)?;
     }
     Ok(())
@@ -237,7 +232,7 @@ pub(crate) fn move_cursor_left(out: &Term, n: usize) -> io::Result<()> {
         return common_term::move_cursor_left(out, n);
     }
 
-    if let Some((_, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+    if let Some((_, csbi)) = get_console_screen_buffer_info(out.as_raw_handle()) {
         move_cursor_to(
             out,
             csbi.dwCursorPosition.X as usize - n,
@@ -252,7 +247,7 @@ pub(crate) fn move_cursor_right(out: &Term, n: usize) -> io::Result<()> {
         return common_term::move_cursor_right(out, n);
     }
 
-    if let Some((_, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+    if let Some((_, csbi)) = get_console_screen_buffer_info(out.as_raw_handle()) {
         move_cursor_to(
             out,
             csbi.dwCursorPosition.X as usize + n,
@@ -266,7 +261,7 @@ pub(crate) fn clear_line(out: &Term) -> io::Result<()> {
     if out.is_msys_tty {
         return common_term::clear_line(out);
     }
-    if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+    if let Some((hand, csbi)) = get_console_screen_buffer_info(out.as_raw_handle()) {
         unsafe {
             let width = csbi.srWindow.Right - csbi.srWindow.Left;
             let pos = COORD {
@@ -286,7 +281,7 @@ pub(crate) fn clear_chars(out: &Term, n: usize) -> io::Result<()> {
     if out.is_msys_tty {
         return common_term::clear_chars(out, n);
     }
-    if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+    if let Some((hand, csbi)) = get_console_screen_buffer_info(out.as_raw_handle()) {
         unsafe {
             let width = cmp::min(csbi.dwCursorPosition.X, n as i16);
             let pos = COORD {
@@ -306,7 +301,7 @@ pub(crate) fn clear_screen(out: &Term) -> io::Result<()> {
     if out.is_msys_tty {
         return common_term::clear_screen(out);
     }
-    if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+    if let Some((hand, csbi)) = get_console_screen_buffer_info(out.as_raw_handle()) {
         unsafe {
             let cells = csbi.dwSize.X as u32 * csbi.dwSize.Y as u32; // as u32, or else this causes stack overflows.
             let pos = COORD { X: 0, Y: 0 };
@@ -323,7 +318,7 @@ pub(crate) fn clear_to_end_of_screen(out: &Term) -> io::Result<()> {
     if out.is_msys_tty {
         return common_term::clear_to_end_of_screen(out);
     }
-    if let Some((hand, csbi)) = get_console_screen_buffer_info(as_handle(out)) {
+    if let Some((hand, csbi)) = get_console_screen_buffer_info(out.as_raw_handle()) {
         unsafe {
             let bottom = csbi.srWindow.Right as u32 * csbi.srWindow.Bottom as u32;
             let cells = bottom - (csbi.dwCursorPosition.X as u32 * csbi.dwCursorPosition.Y as u32); // as u32, or else this causes stack overflows.
@@ -344,7 +339,7 @@ pub(crate) fn show_cursor(out: &Term) -> io::Result<()> {
     if out.is_msys_tty {
         return common_term::show_cursor(out);
     }
-    if let Some((hand, mut cci)) = get_console_cursor_info(as_handle(out)) {
+    if let Some((hand, mut cci)) = get_console_cursor_info(out.as_raw_handle()) {
         unsafe {
             cci.bVisible = 1;
             SetConsoleCursorInfo(hand, &cci);
@@ -357,7 +352,7 @@ pub(crate) fn hide_cursor(out: &Term) -> io::Result<()> {
     if out.is_msys_tty {
         return common_term::hide_cursor(out);
     }
-    if let Some((hand, mut cci)) = get_console_cursor_info(as_handle(out)) {
+    if let Some((hand, mut cci)) = get_console_cursor_info(out.as_raw_handle()) {
         unsafe {
             cci.bVisible = 0;
             SetConsoleCursorInfo(hand, &cci);


### PR DESCRIPTION
`windows-sys` long ago moved to using a std compatible raw handle type.

Adding constructors to `TermInner` makes it much easier to experiment with its implementation.