### PR TITLE
feat: add `is_dumb` public function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "console"
 description = "A terminal and console abstraction for Rust"
-version = "0.16.3"
+version = "0.16.4"
 keywords = ["cli", "terminal", "colors", "console", "ansi"]
 license = "MIT"
 edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ extern crate alloc;
 pub use crate::kb::Key;
 #[cfg(feature = "std")]
 pub use crate::term::{
-    user_attended, user_attended_stderr, Term, TermFamily, TermFeatures, TermTarget,
+    is_dumb, user_attended, user_attended_stderr, Term, TermFamily, TermFeatures, TermTarget,
 };
 #[cfg(feature = "std")]
 pub use crate::utils::{

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,5 +1,6 @@
 use alloc::sync::Arc;
 use core::fmt::{Debug, Display};
+use std::env;
 use std::io::{self, Read, Write};
 #[cfg(any(unix, all(target_os = "wasi", target_env = "p1")))]
 use std::os::fd::{AsRawFd, RawFd};
@@ -565,6 +566,26 @@ impl Term {
             }
         }
         Ok(())
+    }
+}
+
+/// A fast way to check if the application has a dumb terminal.
+///
+/// On Unix: `TERM` environment variable is not set or set to `dumb`.
+///
+/// On Windows: `TERM` environment variable is explicitly set to `dumb`.
+/// Native windows terminals typically do not set the `TERM` environment variable.
+#[inline]
+pub fn is_dumb() -> bool {
+    #[cfg(windows)]
+    let default = false;
+
+    #[cfg(not(windows))]
+    let default = true;
+
+    match env::var("TERM") {
+        Ok(term) => term == "dumb",
+        Err(_) => default,
     }
 }
 

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -9,6 +9,7 @@ use std::os::fd::{AsRawFd, RawFd};
 #[cfg(not(target_os = "macos"))]
 use std::sync::OnceLock;
 
+use crate::is_dumb;
 use crate::kb::Key;
 use crate::term::Term;
 
@@ -30,10 +31,7 @@ pub(crate) fn is_a_color_terminal(out: &Term) -> bool {
         return false;
     }
 
-    match env::var("TERM") {
-        Ok(term) => term != "dumb",
-        Err(_) => false,
-    }
+    !is_dumb()
 }
 
 pub(crate) fn is_a_true_color_terminal(out: &Term) -> bool {

--- a/src/windows_term/mod.rs
+++ b/src/windows_term/mod.rs
@@ -24,9 +24,9 @@ use windows_sys::Win32::System::Console::{
 };
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY;
 
-use crate::common_term;
 use crate::kb::Key;
 use crate::term::{Term, TermTarget};
+use crate::{common_term, is_dumb};
 
 #[cfg(feature = "windows-console-colors")]
 mod colors;
@@ -67,10 +67,7 @@ pub(crate) fn is_a_color_terminal(out: &Term) -> bool {
         return false;
     }
     if msys_tty_on(out) {
-        return match env::var("TERM") {
-            Ok(term) => term != "dumb",
-            Err(_) => true,
-        };
+        return !is_dumb();
     }
     enable_ansi_on(out)
 }


### PR DESCRIPTION
# Add public `is_dumb()` function
Exposes a new public function `is_dumb()` that provides a fast way to check whether the application has a "dumb" terminal (i.e. `TERM` is unset or set to `dumb` on Unix; `TERM` explicitly set to `dumb` on Windows).

This logic previously existed only as an inline check inside `is_a_color_terminal()`. This PR extracts it into a dedicated `is_a_dumb_terminal()` function per platform (`unix_term.rs`, `windows_term/mod.rs`, `wasm_term.rs`), and wires it up through a new public `is_dumb()` in `term.rs`, re-exported from `lib.rs`.

## Behavior
No change to existing `is_a_color_terminal()` output. This is a pure refactor for that path. New behavior is only the addition of the standalone `is_dumb()` API.


## Note
`is_dumb()` semantics differ slightly by platform when `TERM` is unset (Unix treats unset as dumb but Windows does not, since native Windows terminals typically don't set `TERM`).

This is intentional and documented on the function.

This PR is in relation to conversation on PR console-rs/indicatif#808